### PR TITLE
2022.3.x compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "",
     "requirements": [
         "construct==2.10.56",
-        "python-miio==0.5.10"
+        "python-miio==0.5.11"
     ],
     "dependencies": [],
     "codeowners": []

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "",
     "requirements": [
         "construct==2.10.56",
-        "python-miio==0.5.6"
+        "python-miio==0.5.10"
     ],
     "dependencies": [],
     "codeowners": []

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "documentation": "",
     "requirements": [
         "construct==2.10.56",
-        "python-miio==0.5.11"
+        "python-miio>=0.5.11"
     ],
     "dependencies": [],
     "codeowners": []

--- a/vacuum.py
+++ b/vacuum.py
@@ -3,7 +3,7 @@ import asyncio
 from functools import partial
 import logging
 
-from miio import DeviceException, Vacuum  # pylint: disable=import-error
+from miio import DeviceException, RoborockVacuum  # pylint: disable=import-error
 import voluptuous as vol
 
 from homeassistant.components.vacuum import (
@@ -134,7 +134,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
   # Create handler
   _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
-  vacuum = Vacuum(host, token)
+  vacuum = RoborockVacuum(host, token)
 
   mirobo = MiroboVacuum2(name, vacuum)
   hass.data[DATA_KEY][host] = mirobo


### PR DESCRIPTION
Addresses issue #55 

- Bumped python-miio up to version 0.5.11 for compatibility with Home Assistant 2022.3.x
- Replaced deprecated `Vacuum` class (see [python-miio 0.5.11 changelog](https://github.com/rytilahti/python-miio/releases/tag/0.5.11)